### PR TITLE
Btn-xs and Btn-md

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,59 @@
+# List of files for git to ignore
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Vim
+Session.vim
+
+# Node
+node_modules/*
+npm-debug.log
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Vim
+Session.vim
+
+# Node
+node_modules/*
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ git clone git@github.com:mrmrs/tachyons-buttons
 
 
 /*
+ * Button Sizes
+ *
+ * Code:
+ * <a href="#" class="btn btn-xs">
+ * <a href="#" class="btn btn-md">
+ *
+*/
+
+.btn-xs, .btn-xs:link, .btn-xs:visited{
+    padding: .5em .37em !important;
+}
+
+.btn-md, .btn-md:link, .btn-xs:visited{
+    padding: .75em .5em !important;
+}
+
+
+/*
 
   Layout utility for responsive buttons
 

--- a/src/tachyons-buttons.css
+++ b/src/tachyons-buttons.css
@@ -53,6 +53,7 @@
  *
  * Code:
  * <a href="#" class="btn btn-xs">
+ * <a href="#" class="btn btn-md">
  *
 */
 

--- a/src/tachyons-buttons.css
+++ b/src/tachyons-buttons.css
@@ -48,6 +48,21 @@
   transition: background-color .3s, color .3s, border .3s;
 }
 
+/*
+ * Button Sizes
+ *
+ * Code:
+ * <a href="#" class="btn btn-xs">
+ *
+*/
+
+.btn-xs, .btn-xs:link, .btn-xs:visited{
+    padding: .5em .37em !important;
+}
+
+.btn-md, .btn-md:link, .btn-xs:visited{
+    padding: .75em .5em !important;
+}
 
 /*
 


### PR DESCRIPTION
Sometimes different button sizes are required. In an app bundled by webpack, pa1 (for setting padding), doesn't work, due to having a different code hierarchy than expected. Hence, i'm using the '!important' directive, to give the declaration more weight.